### PR TITLE
[fix]: Use direct 'new' in EntityManager

### DIFF
--- a/EcoSimEngine.vcxproj.filters
+++ b/EcoSimEngine.vcxproj.filters
@@ -41,9 +41,6 @@
     <ClInclude Include="include\Entity.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="include\EntityManager.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="include\Scene.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -60,6 +57,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\nlohmann\json.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\EntityManager.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/include/EntityManager.hpp
+++ b/include/EntityManager.hpp
@@ -69,7 +69,9 @@ public:
     }
 
     std::shared_ptr<Entity> addEntity(const std::string& tag) {
-        auto entity = std::make_shared<Entity>(m_totalEntities++, tag);
+        // Must use 'new' here instead of std::make_shared because Entity's constructor is private.
+        // std::make_shared constructs outside EntityManager, so it cannot access private constructors despite friendship.
+        std::shared_ptr<Entity> entity(new Entity(m_totalEntities++, tag));
         m_entitiesToAdd.push_back(entity);
         return entity;
     }


### PR DESCRIPTION


Entity has a private constructor, which prevents std::make_shared from 
being used. This change reverts the earlier switch to make_shared and 
restores direct usage of 'new' wrapped in a shared_ptr.

- Fixes runtime error when creating entities
- Preserves shared ownership semantics
- Documents limitation of make_shared with private constructors
