### PR TITLE
[feat]: Refactor input handling to use sf::Keyboard::Key

### DIFF
--- a/include/Scene.hpp
+++ b/include/Scene.hpp
@@ -11,7 +11,7 @@
 // Forward declaration to break circular include
 class SimulationEngine;
 
-using ActionMap = std::map<int, std::string>;
+using ActionMap = std::map<sf::Keyboard::Key, std::string>;
 
 class Scene {
 protected:
@@ -37,7 +37,7 @@ public:
     virtual void doAction(const Action& action);
 
     void simulate(size_t frames);
-    void registerAction(int inputKey, const std::string& actionName);
+    void registerAction(sf::Keyboard::Key inputKey, const std::string& actionName);
 
     [[nodiscard]] float width() const;
     [[nodiscard]] float height() const;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -24,7 +24,7 @@ void Scene::simulate(size_t frames) {
     // Default empty implementation
 }
 
-void Scene::registerAction(int inputKey, const std::string& actionName) {
+void Scene::registerAction(sf::Keyboard::Key inputKey, const std::string& actionName) {
     m_actionMap[inputKey] = actionName;
 }
 

--- a/src/SimulationEngine.cpp
+++ b/src/SimulationEngine.cpp
@@ -114,14 +114,14 @@ void SimulationEngine::sUserInput() {
 
         if (auto keyEvent = event.getIf<sf::Event::KeyPressed>()) {
             int keyInt = static_cast<int>(keyEvent->code);
-            auto it = currentScene()->getActionMap().find(keyInt);
+            auto it = currentScene()->getActionMap().find(static_cast<sf::Keyboard::Key>(keyInt));
             if (it != currentScene()->getActionMap().end()) {
                 currentScene()->doAction(Action(it->second, "START"));
             }
         }
         else if (auto keyEvent = event.getIf<sf::Event::KeyReleased>()) {
             int keyInt = static_cast<int>(keyEvent->code);
-            auto it = currentScene()->getActionMap().find(keyInt);
+            auto it = currentScene()->getActionMap().find(static_cast<sf::Keyboard::Key>(keyInt));
             if (it != currentScene()->getActionMap().end()) {
                 currentScene()->doAction(Action(it->second, "END"));
             }


### PR DESCRIPTION
Refactored input system for stronger type safety:

- Changed ActionMap and registerAction to use sf::Keyboard::Key instead of int.
- Updated SimulationEngine::sUserInput to match new ActionMap key type.

This ensures clearer intent, avoids implicit casts, and prevents input-related bugs in future expansions.