### PR TITLE
[feat]: implement menu navigation and rendering logic

### DIFF
--- a/include/Scene_Menu.hpp
+++ b/include/Scene_Menu.hpp
@@ -7,6 +7,8 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/Audio.hpp>
 
+#include <memory>
+
 enum class MenuState {
     Main,
     SubMenu
@@ -16,9 +18,10 @@ class Scene_Menu : public Scene {
 protected:
     MenuState m_menuState{ MenuState::Main };
 
+    std::unique_ptr<sf::Text> m_titleText;
     std::string m_title{ "Main Menu" };
 
-    std::vector<std::string> m_mainItems{ "Start", "Load", "Options", "Quit" };
+    std::vector<std::string> m_mainItems{ "New", "Load", "Options", "Quit" };
     std::vector<std::string> m_subItems{ "Simulation1", "Simulation2", "Simulation3" };
 
     std::vector<sf::Text> m_mainTexts;

--- a/src/Scene_Menu.cpp
+++ b/src/Scene_Menu.cpp
@@ -28,12 +28,23 @@ void Scene_Menu::init() {
     registerAction(sf::Keyboard::Key::Escape, "BACK");
 
     // Load sound
-
     sf::Sound& m_titleMusic = m_simulation->assets().getSound("Foo");
     m_titleMusic.play();
 
 
     const sf::Font& font = m_simulation->assets().getFont("Main");
+
+	// Create title text
+    m_titleText = std::make_unique<sf::Text>(font, sf::String(m_title), 48);
+    m_titleText->setFillColor(sf::Color::White);
+    //    // Center origin
+    sf::FloatRect textRect = m_titleText->getLocalBounds();
+    m_titleText->setOrigin({ textRect.size.x / 2.f, textRect.size.y / 2.f });
+    m_titleText->setPosition({
+        m_simulation->window().getSize().x / 2.f,
+        50.f }
+    );
+
 
     // Create main menu texts
     for (size_t i = 0; i < m_mainItems.size(); ++i)
@@ -49,20 +60,64 @@ void Scene_Menu::init() {
         m_subTexts.back().setFillColor(sf::Color::White);
         m_subTexts.back().setPosition({ 150.f, 150.f + i * 40.f });
     }
-
-
 }
 
 
 
 
 void Scene_Menu::sDoAction(const Action& action) {
-  /*  if (m_menuState == MenuState::Main)
-    {
-        if (action.name == "Up") {}
-    }
+    if (action.type() != "START") return; // <-- ignore auto-repeat and END events
 
-    */
+    if (m_menuState == MenuState::Main)
+    {
+        if (action.name() == "UP") {
+            if (m_selectedMainIndex == 0)
+                m_selectedMainIndex = m_mainItems.size() - 1;
+            else
+                --m_selectedMainIndex;
+        }
+        if (action.name() == "DOWN") {
+            m_selectedMainIndex = (m_selectedMainIndex + 1) % m_mainItems.size();
+        }
+        if (action.name() == "SELECT") {
+            if (m_selectedMainIndex == 1) { // Load -> switch to sub-menu
+                m_menuState = MenuState::SubMenu;
+                m_selectedSubIndex = 0;
+            }
+            else if (m_selectedMainIndex == 3) { // Quit
+                onEnd();
+            }
+        }
+
+        // Update colours
+		for (size_t i = 0; i < m_mainTexts.size(); ++i) {
+			m_mainTexts[i].setFillColor((i == m_selectedMainIndex) ? sf::Color::Yellow : sf::Color::White);
+		}
+
+    }
+    else if (m_menuState == MenuState::SubMenu) {
+        if (action.name() == "UP") {
+            if (m_selectedSubIndex == 0)
+                m_selectedSubIndex = m_subItems.size() - 1;
+            else
+                --m_selectedSubIndex;
+        }
+        if (action.name() == "DOWN") {
+            m_selectedSubIndex = (m_selectedSubIndex + 1) % m_subItems.size();
+        }
+        if (action.name() == "BACK") {
+            m_menuState = MenuState::Main;
+        }
+        else if (action.name() == "SELECT") {
+            // TODO: Handle Sub-menu selection
+            // something like
+            //      //   m_game->changeScene("PLAY", std::make_shared<Scene_Simulation>(m_game, __SIMULATION_FILE_HERE__));
+
+        }
+
+        for (size_t i = 0; i < m_subTexts.size(); ++i)
+            m_subTexts[i].setFillColor(i == m_selectedSubIndex ? sf::Color::Yellow : sf::Color::White);
+    }
 }
 
 
@@ -72,6 +127,10 @@ void Scene_Menu::sRender() {
 
     // Clear window with charcoal background
     window.clear(sf::Color(31, 31, 31));
+
+	// Draw title text
+    if (m_titleText) window.draw(*m_titleText);
+
 
     // Draw rectangle in the center
     sf::RectangleShape rect;
@@ -83,18 +142,18 @@ void Scene_Menu::sRender() {
     );
     window.draw(rect);
 
-    //  Draw menu texts
-    for (auto& text : m_mainTexts) {
-        window.draw(text);
+    // draw menu texts depends on the MenuState
+    if (m_menuState == MenuState::Main) {
+        for (auto& text : m_mainTexts) {
+            window.draw(text);
+        }
     }
-    for (auto& text : m_subTexts) {
-        window.draw(text);
+    else if (m_menuState == MenuState::SubMenu) {
+        for (auto& text : m_subTexts) {
+            window.draw(text);
+        }
     }
-
 }
-
-
-
 
 
 

--- a/src/SimulationEngine.cpp
+++ b/src/SimulationEngine.cpp
@@ -113,15 +113,13 @@ void SimulationEngine::sUserInput() {
 
 
         if (auto keyEvent = event.getIf<sf::Event::KeyPressed>()) {
-            int keyInt = static_cast<int>(keyEvent->code);
-            auto it = currentScene()->getActionMap().find(static_cast<sf::Keyboard::Key>(keyInt));
+            auto it = currentScene()->getActionMap().find(keyEvent->code);
             if (it != currentScene()->getActionMap().end()) {
                 currentScene()->doAction(Action(it->second, "START"));
             }
         }
         else if (auto keyEvent = event.getIf<sf::Event::KeyReleased>()) {
-            int keyInt = static_cast<int>(keyEvent->code);
-            auto it = currentScene()->getActionMap().find(static_cast<sf::Keyboard::Key>(keyInt));
+            auto it = currentScene()->getActionMap().find(keyEvent->code);
             if (it != currentScene()->getActionMap().end()) {
                 currentScene()->doAction(Action(it->second, "END"));
             }


### PR DESCRIPTION
Implement functional menu navigation and rendering in Scene_Menu

- Use std::unique_ptr for m_titleText to manage memory safely.
- Update main menu items ("Start" → "New") and add sub-menu items.
- Implement navigation logic for main and sub-menus with color highlighting for selected items.
- Clean up rendering in Scene_Menu::sRender() to draw texts according to current MenuState.

- Simplify key event handling in SimulationEngine::sUserInput() for direct mapping.