### PR TITLE
[refactor]: Replace string-based Action with enums

### DIFF
--- a/include/Action.hpp
+++ b/include/Action.hpp
@@ -1,44 +1,70 @@
 #pragma once
 
 #include <string>
-#include <sstream>
+#include <format>
 
 #include "Vec2.hpp"
 
+enum class ActionName {
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT,
+    SELECT,
+    BACK,
+	LEFT_CLICK,
+	MIDDLE_CLICK,
+	RIGHT_CLICK,
+	MOUSE_MOVE,
+    NONE
+};
+
+enum class ActionType {
+	START,
+	END,
+    NONE
+};
 
 class Action {
-    std::string m_name;
-    std::string m_type;
+    ActionName m_name;
+    ActionType m_type;
     Vec2f m_pos{}; // default to (0,0)
 
 public:
     Action() = default;
 
     /// Constructs an Action with a name, type, and position.
-    Action(std::string name, std::string type, Vec2f pos)
-        : m_name(std::move(name)), m_type(std::move(type)), m_pos(pos) {
+    Action(ActionName name, ActionType type, Vec2f pos)
+        : m_name{ name }, m_type{ type }, m_pos{ pos } {
     }
 
     /// Constructs an Action with name and type, position defaults to (0,0).
-    Action(std::string name, std::string type)
-        : Action(std::move(name), std::move(type), Vec2f{}) {
+    Action(ActionName name, ActionType type)
+        : Action{ name, type, Vec2f{} } {
     }
 
-    /// Constructs an Action with name and position, type defaults to "".
-    Action(std::string name, Vec2f pos)
-        : Action(std::move(name), "", pos) {
+    /// Constructs an Action with name and position, type defaults to NONE.
+    Action(ActionName name, Vec2f pos)
+        : Action{ name, ActionType::NONE, pos } {
     }
 
-    [[nodiscard]] const std::string& name() const  noexcept { return m_name; }
-    [[nodiscard]] const std::string& type() const noexcept { return m_type; }
+    [[nodiscard]] const ActionName name() const  noexcept { return m_name; }
+    [[nodiscard]] const ActionType type() const noexcept { return m_type; }
     [[nodiscard]] const Vec2f& pos() const noexcept { return m_pos; }
 
-    [[nodiscard]] std::string toString() const
-    {
-        std::stringstream ss;
-        ss << name() << " " << type() << " "
-            << static_cast<int>(pos().x) << " "
-            << static_cast<int>(pos().y);
-        return ss.str();
+    [[nodiscard]] std::string toString() const noexcept {
+        static constexpr const char* NameStrings[] = {
+            "UP", "DOWN", "LEFT", "RIGHT", "SELECT", "BACK", "NONE", 
+            "LEFT_CLICK","MIDDLE_CLICK","RIGHT_CLICK","MOUSE_MOVE",
+        };
+        static constexpr const char* TypeStrings[] = {
+            "START", "END", "NONE"
+        };
+
+        return std::format("{} {} {} {}",
+            NameStrings[static_cast<int>(m_name)],
+            TypeStrings[static_cast<int>(m_type)],
+            static_cast<int>(m_pos.x),
+            static_cast<int>(m_pos.y));
     }
 };

--- a/include/Scene.hpp
+++ b/include/Scene.hpp
@@ -11,7 +11,7 @@
 // Forward declaration to break circular include
 class SimulationEngine;
 
-using ActionMap = std::map<sf::Keyboard::Key, std::string>;
+using ActionMap = std::map<sf::Keyboard::Key, ActionName>;
 
 class Scene {
 protected:
@@ -37,7 +37,7 @@ public:
     virtual void doAction(const Action& action);
 
     void simulate(size_t frames);
-    void registerAction(sf::Keyboard::Key inputKey, const std::string& actionName);
+    void registerAction(sf::Keyboard::Key inputKey, const ActionName actionName);
 
     [[nodiscard]] float width() const;
     [[nodiscard]] float height() const;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -24,7 +24,7 @@ void Scene::simulate(size_t frames) {
     // Default empty implementation
 }
 
-void Scene::registerAction(sf::Keyboard::Key inputKey, const std::string& actionName) {
+void Scene::registerAction(sf::Keyboard::Key inputKey, const ActionName actionName) {
     m_actionMap[inputKey] = actionName;
 }
 

--- a/src/Scene_Menu.cpp
+++ b/src/Scene_Menu.cpp
@@ -22,10 +22,10 @@ void Scene_Menu::init() {
     m_simulation->window().setView(view);
 
 	// Register actions for the menu
-    registerAction(sf::Keyboard::Key::W, "UP");
-    registerAction(sf::Keyboard::Key::S, "DOWN");
-    registerAction(sf::Keyboard::Key::Enter, "SELECT");
-    registerAction(sf::Keyboard::Key::Escape, "BACK");
+    registerAction(sf::Keyboard::Key::W, ActionName::UP);
+    registerAction(sf::Keyboard::Key::S, ActionName::DOWN);
+    registerAction(sf::Keyboard::Key::Enter, ActionName::SELECT);
+    registerAction(sf::Keyboard::Key::Escape, ActionName::BACK);
 
     // Load sound
     sf::Sound& m_titleMusic = m_simulation->assets().getSound("Foo");
@@ -66,20 +66,20 @@ void Scene_Menu::init() {
 
 
 void Scene_Menu::sDoAction(const Action& action) {
-    if (action.type() != "START") return; // <-- ignore auto-repeat and END events
+    if (action.type() != ActionType::START) return; // <-- ignore auto-repeat and END events
 
     if (m_menuState == MenuState::Main)
     {
-        if (action.name() == "UP") {
+        if (action.name() == ActionName::UP) {
             if (m_selectedMainIndex == 0)
                 m_selectedMainIndex = m_mainItems.size() - 1;
             else
                 --m_selectedMainIndex;
         }
-        if (action.name() == "DOWN") {
+        if (action.name() == ActionName::DOWN) {
             m_selectedMainIndex = (m_selectedMainIndex + 1) % m_mainItems.size();
         }
-        if (action.name() == "SELECT") {
+        if (action.name() == ActionName::SELECT) {
             if (m_selectedMainIndex == 1) { // Load -> switch to sub-menu
                 m_menuState = MenuState::SubMenu;
                 m_selectedSubIndex = 0;
@@ -96,19 +96,19 @@ void Scene_Menu::sDoAction(const Action& action) {
 
     }
     else if (m_menuState == MenuState::SubMenu) {
-        if (action.name() == "UP") {
+        if (action.name() == ActionName::UP) {
             if (m_selectedSubIndex == 0)
                 m_selectedSubIndex = m_subItems.size() - 1;
             else
                 --m_selectedSubIndex;
         }
-        if (action.name() == "DOWN") {
+        if (action.name() == ActionName::DOWN) {
             m_selectedSubIndex = (m_selectedSubIndex + 1) % m_subItems.size();
         }
-        if (action.name() == "BACK") {
+        if (action.name() == ActionName::BACK) {
             m_menuState = MenuState::Main;
         }
-        else if (action.name() == "SELECT") {
+        else if (action.name() == ActionName::SELECT) {
             // TODO: Handle Sub-menu selection
             // something like
             //      //   m_game->changeScene("PLAY", std::make_shared<Scene_Simulation>(m_game, __SIMULATION_FILE_HERE__));

--- a/src/SimulationEngine.cpp
+++ b/src/SimulationEngine.cpp
@@ -115,13 +115,13 @@ void SimulationEngine::sUserInput() {
         if (auto keyEvent = event.getIf<sf::Event::KeyPressed>()) {
             auto it = currentScene()->getActionMap().find(keyEvent->code);
             if (it != currentScene()->getActionMap().end()) {
-                currentScene()->doAction(Action(it->second, "START"));
+                currentScene()->doAction(Action(it->second, ActionType::START));
             }
         }
         else if (auto keyEvent = event.getIf<sf::Event::KeyReleased>()) {
             auto it = currentScene()->getActionMap().find(keyEvent->code);
             if (it != currentScene()->getActionMap().end()) {
-                currentScene()->doAction(Action(it->second, "END"));
+                currentScene()->doAction(Action(it->second, ActionType::END));
             }
         }
 
@@ -136,13 +136,13 @@ void SimulationEngine::sUserInput() {
         if (auto mb = event.getIf<sf::Event::MouseButtonPressed>()) {
             switch (mb->button) {
             case sf::Mouse::Button::Left:
-                currentScene()->doAction(Action("LEFT_CLICK", "START", pos));
+                currentScene()->doAction(Action(ActionName::LEFT_CLICK, ActionType::START, pos));
                 break;
             case sf::Mouse::Button::Middle:
-                currentScene()->doAction(Action("MIDDLE_CLICK", "START", pos));
+                currentScene()->doAction(Action(ActionName::MIDDLE_CLICK, ActionType::START, pos));
                 break;
             case sf::Mouse::Button::Right:
-                currentScene()->doAction(Action("RIGHT_CLICK", "START", pos));
+                currentScene()->doAction(Action(ActionName::RIGHT_CLICK, ActionType::START, pos));
                 break;
             default:
                 break;
@@ -152,13 +152,13 @@ void SimulationEngine::sUserInput() {
         if (auto mb = event.getIf<sf::Event::MouseButtonReleased>()) {
             switch (mb->button) {
             case sf::Mouse::Button::Left:
-                currentScene()->doAction(Action("LEFT_CLICK", "END", pos));
+                currentScene()->doAction(Action(ActionName::LEFT_CLICK, ActionType::END, pos));
                 break;
             case sf::Mouse::Button::Middle:
-                currentScene()->doAction(Action("MIDDLE_CLICK", "END", pos));
+                currentScene()->doAction(Action(ActionName::MIDDLE_CLICK, ActionType::END, pos));
                 break;
             case sf::Mouse::Button::Right:
-                currentScene()->doAction(Action("RIGHT_CLICK", "END", pos));
+                currentScene()->doAction(Action(ActionName::RIGHT_CLICK, ActionType::END, pos));
                 break;
             default:
                 break;
@@ -167,7 +167,7 @@ void SimulationEngine::sUserInput() {
 
         // --- Mouse Move ---
         if (auto mm = event.getIf<sf::Event::MouseMoved>()) {
-            currentScene()->doAction(Action("MOUSE_MOVE", Vec2f(static_cast<float>(mm->position.x), static_cast<float>(mm->position.y))));
+            currentScene()->doAction(Action(ActionName::MOUSE_MOVE, Vec2f(static_cast<float>(mm->position.x), static_cast<float>(mm->position.y))));
         }
     }
 }


### PR DESCRIPTION
Replaced all string-based action names and types with strongly-typed enums (ActionName, ActionType) throughout the codebase.

Changes include:
- Updated Action class to store ActionName and ActionType instead of std::string.
- Updated Scene, Scene_Menu, and SimulationEngine to use the new enums.
- ActionMap now maps sf::Keyboard::Key to ActionName.
- Replaced string comparisons with enum comparisons for type safety.
- Updated mouse actions to use ActionName/ActionType enums.
- Improved type safety and reduced risk of errors from string mismatches.

This refactor improves code maintainability and aligns with industry best practices for strongly-typed action handling.