### PR TITLE
[Refactor]: Refactor Scene_Simulation to support structured save/load…

### DIFF
--- a/include/EcoSimEngine/scene/Scene_Simulation.hpp
+++ b/include/EcoSimEngine/scene/Scene_Simulation.hpp
@@ -50,4 +50,7 @@ public:
     Scene_Simulation(SimulationEngine* simulationEngine, const std::string& simKey = {}); // Constructor takes in specific simulation name
 
     void update() override;
+
+	// helpers
+    std::string buildSavePathFromKey(const std::string& key);
 };


### PR DESCRIPTION
… flow

Refactored Scene_Simulation to improve handling of save and default simulation loading.

Changes:
- Added buildSavePathFromKey() helper for consistent save file mapping.
- Updated init() to check for named saves before falling back to default.
- Consolidated EntityManager reset and SystemManager attachment logic.
- Improved error handling for missing or malformed JSON files.
- Unified spawnFromJson() to use simJson consistently.
- Streamlined species color assignment and RNG setup.
- Removed redundant and unused code for clarity.

This refactor prepares the engine for robust save/load functionality while maintaining backward compatibility with default simulations.