### PR TITLE
refactor(ecs): centralise EntityManager & ComponentManager in SimulationEngine

### DIFF
--- a/include/EcoSimEngine/SimulationEngine.hpp
+++ b/include/EcoSimEngine/SimulationEngine.hpp
@@ -28,6 +28,9 @@ protected:
     bool m_running{ true };
     std::shared_ptr<Scene> currentScene();
 
+     ComponentManager m_componentManager; // REFACTORING ADD
+     EntityManager m_entityManager;
+
 
     void init(const std::string& path);
 
@@ -53,6 +56,8 @@ public:
 
     bool isRunning() const;
 
-    SceneManager& sceneManager();
-	SystemManager& systemManager();
+    SceneManager& sceneManager() noexcept { return m_sceneManager; }
+    SystemManager& systemManager() noexcept { return m_systemManager; }
+    EntityManager& entityManager() noexcept { return m_entityManager; }
+    ComponentManager& componentManager() noexcept { return m_componentManager; }
 };

--- a/include/EcoSimEngine/ecs/EntityManager.hpp
+++ b/include/EcoSimEngine/ecs/EntityManager.hpp
@@ -159,4 +159,37 @@ public:
     {
 		return m_entityMap;
     }
+
+    void clearAll() noexcept {
+        // 1) Mark all entities destroyed and notify systems to remove them
+        for (const auto& entity : m_entities) {
+            if (!entity) continue;
+            if (entity->isActive()) entity->destroy();
+            if (m_systemManager) m_systemManager->EntityDestroyed(entity->id());
+        }
+
+        for (const auto& entity : m_entitiesToAdd) {
+            if (!entity) continue;
+            if (entity->isActive()) entity->destroy();
+            if (m_systemManager) m_systemManager->EntityDestroyed(entity->id());
+        }
+
+        // 2) Clear all component storage to avoid stale components
+        if (m_componentManager) {
+            m_componentManager->clear();
+        }
+
+        // 3) Remove all entities from our containers
+        m_entities.clear();
+        m_entitiesToAdd.clear();
+        m_entityMap.clear();
+
+        // 4) Reset entity counter and any ID-recycling structures (if present)
+        m_totalEntities = 0;
+        // If you later add a free-id vector or id-indexed storage, clear it here too:
+        // m_freeIds.clear();
+        // m_entitiesById.clear();
+    }
+
+
 };

--- a/include/EcoSimEngine/scene/Scene.hpp
+++ b/include/EcoSimEngine/scene/Scene.hpp
@@ -17,8 +17,8 @@ using ActionMap = std::map<sf::Keyboard::Key, ActionName>;
 class Scene {
 protected:
     SimulationEngine* m_simulation{ nullptr };
-    EntityManager m_entityManager;
-	ComponentManager m_componentManager;
+    // EntityManager m_entityManager;
+	// ComponentManager m_componentManager; // REFACTORING
     ActionMap m_actionMap;
     bool m_paused{ false };
     bool m_hasEnded{ false };

--- a/src/SimulationEngine.cpp
+++ b/src/SimulationEngine.cpp
@@ -15,7 +15,11 @@
 #include "EcoSimEngine/system/AISystem.hpp"
 
 
-SimulationEngine::SimulationEngine(const std::string& path) {
+SimulationEngine::SimulationEngine(const std::string& path)
+    : m_systemManager()
+    , m_componentManager()
+    , m_entityManager(&m_systemManager, &m_componentManager)
+{
     init(path);
 }
 
@@ -206,7 +210,3 @@ void SimulationEngine::update() {
 Assets& SimulationEngine::assets() {
     return m_assets;
 }
-
-SceneManager& SimulationEngine::sceneManager() { return m_sceneManager; }
-SystemManager& SimulationEngine::systemManager() { return m_systemManager; }
-


### PR DESCRIPTION
Motivation:
- Avoid inconsistent ECS wiring: Scene-local managers could not reliably notify engine-owned SystemManager about signature changes.
- Single source of truth for entities/components improves maintainability and reduces subtle bugs when scenes change.

What changed:
- SimulationEngine now owns SystemManager, ComponentManager and EntityManager.
- EntityManager is constructed with pointers to SystemManager and ComponentManager.
- Scenes no longer own their own EntityManager/ComponentManager; they access them via SimulationEngine::entityManager() / componentManager().
- Added accessors: SimulationEngine::entityManager(), ::componentManager().
- Updated scene constructors/usages to use m_simulation->entityManager() instead of local members.

Files touched (examples):
- include/EcoSimEngine/SimulationEngine.hpp
- src/SimulationEngine.cpp
- include/EcoSimEngine/scene/Scene.hpp
- src/scene/Scene.cpp
- src/scene/Scene_Simulation.cpp

Migration notes:
- Any code that used `scene.m_entityManager` or `scene.m_componentManager` must be updated to `m_simulation->entityManager()` / `m_simulation->componentManager()`.