### PR TITLE
fix(system-manager): guard signature lookup & reserve maps to avoid reallocs

### DIFF
--- a/include/EcoSimEngine/SimulationEngine.hpp
+++ b/include/EcoSimEngine/SimulationEngine.hpp
@@ -22,23 +22,21 @@ protected:
     sf::RenderWindow m_window;
     sf::Clock m_deltaClock; // for imgui
     Assets m_assets;
+
     SceneManager m_sceneManager;
-	SystemManager m_systemManager;
+    SystemManager m_systemManager;
+    ComponentManager m_componentManager;
+    EntityManager m_entityManager;
+
     size_t m_simulationSpeed{ 1 };
     bool m_running{ true };
     std::shared_ptr<Scene> currentScene();
-
-     ComponentManager m_componentManager; // REFACTORING ADD
-     EntityManager m_entityManager;
-
 
     void init(const std::string& path);
 
     void update();
 
     void sUserInput();
-
-    
 
 public:
     explicit SimulationEngine(const std::string& path);

--- a/include/EcoSimEngine/scene/Scene.hpp
+++ b/include/EcoSimEngine/scene/Scene.hpp
@@ -17,8 +17,6 @@ using ActionMap = std::map<sf::Keyboard::Key, ActionName>;
 class Scene {
 protected:
     SimulationEngine* m_simulation{ nullptr };
-    // EntityManager m_entityManager;
-	// ComponentManager m_componentManager; // REFACTORING
     ActionMap m_actionMap;
     bool m_paused{ false };
     bool m_hasEnded{ false };

--- a/include/EcoSimEngine/system/SystemManager.hpp
+++ b/include/EcoSimEngine/system/SystemManager.hpp
@@ -13,6 +13,14 @@ class SystemManager {
     std::unordered_map<std::type_index, Signature> m_signatures{};
     std::unordered_map<std::type_index, std::shared_ptr<System>> m_systems{};
 public:
+    SystemManager() {
+        m_systems.reserve(16);          // reserve a small number, TWEAK as needed
+		m_signatures.reserve(16);
+    }
+
+
+
+
     // Register a system and return a shared_ptr to it
     template<typename T, typename... Args>
     std::shared_ptr<T> RegisterSystem(Args&&... args) {
@@ -41,7 +49,9 @@ public:
     // Called when an entity's signature changed (add/remove component)
     void EntitySignatureChanged(EntityId id, const Signature& entitySignature) {
         for (auto& [type, system] : m_systems) {
-            const Signature& sSig = m_signatures[type];
+            auto sIt = m_signatures.find(type);
+            if (sIt == m_signatures.end()) continue; // no signature set
+            const Signature& sSig = sIt->second;
             if ((entitySignature & sSig) == sSig) system->mEntities.insert(id);
             else system->mEntities.erase(id);
         }


### PR DESCRIPTION
Avoid using m_signatures[type] which can insert a default entry when the signature for a system hasn't been set. Use find() to look up signatures safely and skip systems without a configured signature.

Also reserve capacity for the internal maps to reduce rehashing and heap allocations during system registration and runtime checks. This improves performance in hot paths and avoids unexpected allocations during the first few system registrations.

Why:
- Prevents accidental insertion into m_signatures during signature checks.
- Avoids unnecessary allocations / default-constructed Signature.
- Reduces map rehashing/allocation overhead by reserving expected capacity.
- Makes intent explicit and reduces chance of logic bugs when systems are registered but have no signature set.

What changed:
- Use m_signatures.find(type) in EntitySignatureChanged and skip missing entries.
- Add small SystemManager constructor that calls reserve() on internal maps.